### PR TITLE
設定ファイルのパスを修正

### DIFF
--- a/Clipshort/Settings.swift
+++ b/Clipshort/Settings.swift
@@ -89,7 +89,7 @@ struct Settings {
         } catch {
             let alert = NSAlert()
             alert.messageText = "エラー"
-            alert.informativeText = "設定ファイルの読込に失敗しました。~/clipshortrc.json を確認するか、一度削除してください。"
+            alert.informativeText = "設定ファイルの読込に失敗しました。~/.clipshortrc.json を確認するか、一度削除してください。"
             alert.alertStyle = .warning
             alert.addButton(withTitle: "再試行")
             alert.buttons[0].tag = NSApplication.ModalResponse.OK.rawValue

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 
 ### 設定
 
-`/settings` と入力して実行することにより、設定用 JSON ファイル（`~/clipshortrc.json`）が開きます。JSON ファイルは、以下の通りに指定されます。
+`/settings` と入力して実行することにより、設定用 JSON ファイル（`~/.clipshortrc.json`）が開きます。JSON ファイルは、以下の通りに指定されます。
 
 ```json
 {


### PR DESCRIPTION
README.md およびアラートの設定ファイルのパスが実際のパス（~/.clipshortrc.json）と異なっていたため修正
fix: #6