### PR TITLE
OpenRouter へのサポートを追加

### DIFF
--- a/Clipshort/Request.swift
+++ b/Clipshort/Request.swift
@@ -10,14 +10,22 @@ import Foundation
 struct Request {
     static func fetchOpenAIApi(content: String, completion: @escaping (String) -> Void) {
         // リクエストを準備
-        let endpoint = "https://openrouter.ai/api/v1/chat/completions"
+        // プロバイダーに基づいてエンドポイントを決定
+        let endpoint: String
+        if Settings.llmProvider == "openrouter" {
+            endpoint = "https://openrouter.ai/api/v1/chat/completions"
+        } else {
+            endpoint = "https://api.openai.com/v1/chat/completions"
+        }
         var request = URLRequest(url: URL(string: endpoint)!)
         request.httpMethod = "POST"
         request.addValue("Bearer \(Settings.llmApiKey)", forHTTPHeaderField: "Authorization")
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        // OpenRouterの追加ヘッダー（オプショナル）
-        request.addValue("dev.yokohama.clipshort", forHTTPHeaderField: "HTTP-Referer")
-        request.addValue("Clipshort", forHTTPHeaderField: "X-Title")
+        // OpenRouterの場合は追加ヘッダーを設定
+        if Settings.llmProvider == "openrouter" {
+            request.addValue("dev.yokohama.clipshort", forHTTPHeaderField: "HTTP-Referer")
+            request.addValue("Clipshort", forHTTPHeaderField: "X-Title")
+        }
         
         let body: [String: Any] = [
             "messages": [
@@ -30,7 +38,7 @@ struct Request {
                     "content": content,
                 ],
             ],
-            "model": Settings.llmModel,
+            "model": Settings.formattedModelName,
         ]
         do {
             let jsonData = try JSONSerialization.data(withJSONObject: body, options: [])
@@ -58,13 +66,12 @@ struct Request {
                     completion(content)
                 } else if let error = jsonResponse?["error"] as? [String: Any],
                           let message = error["message"] as? String {
-                   // OpenRouterのエラーメッセージを表示
-                   completion("API Error: \(message)")
-               } else {
+                    completion("API Error: \(message)")
+                } else {
                     completion("Invalid request. Please check llm.apiKey or llm.model.")
                 }
             } catch {
-                completion("Failed to fetch API")
+                completion("Failed to fetch API: \(error.localizedDescription)")
             }
         }
         task.resume()

--- a/Clipshort/Settings.swift
+++ b/Clipshort/Settings.swift
@@ -15,7 +15,7 @@ struct Settings {
     private static var config: Config?
     
     private static let defaultDefault = "llm"
-    private static let defaultLlmModel = "gpt-4o-mini"
+    private static let defaultLlmModel = "openai/gpt-4o-mini"
     private static let defaultSystemPrompt = "以下の質問に簡潔に回答してください"
     private static let defaultShellBin = "/bin/zsh"
     private static let defaultShellInitial = "source ~/.zshrc"

--- a/Clipshort/Settings.swift
+++ b/Clipshort/Settings.swift
@@ -15,6 +15,7 @@ struct Settings {
     private static var config: Config?
     
     private static let defaultDefault = "llm"
+    private static let defaultLlmProvider = "openai"
     private static let defaultLlmModel = "openai/gpt-4o-mini"
     private static let defaultSystemPrompt = "以下の質問に簡潔に回答してください"
     private static let defaultShellBin = "/bin/zsh"
@@ -24,11 +25,24 @@ struct Settings {
     static var isDefaultLLM: Bool {
         return (config?.defaultMode ?? defaultDefault) == "llm"
     }
+    static var llmProvider: String {
+        return config?.llm.provider ?? defaultLlmProvider
+    }
     static var llmApiKey: String {
         return config?.llm.apiKey ?? ""
     }
     static var llmModel: String {
         return config?.llm.model ?? defaultLlmModel
+    }
+    static var formattedModelName: String {
+        let model = llmModel
+        // OpenAIプロバイダーの場合、"openai/gpt-4o" から "gpt-4o" のようにプロバイダー部分を削除
+        if llmProvider == "openai" && model.contains("/") {
+            if let index = model.firstIndex(of: "/") {
+                return String(model[model.index(after: index)...])
+            }
+        }
+        return model
     }
     static var systemPrompt: String {
         return config?.llm.systemPrompt ?? defaultSystemPrompt
@@ -56,7 +70,7 @@ struct Settings {
     private static func newFile() {
         let config = Config(
             defaultMode: "llm",
-            llm: ConfigLLM(apiKey: "YOUR_API_KEY", model: defaultLlmModel, systemPrompt: defaultSystemPrompt),
+            llm: ConfigLLM(apiKey: "YOUR_API_KEY", model: defaultLlmModel, systemPrompt: defaultSystemPrompt, provider: defaultLlmProvider),
             shell: ConfigShell(bin: defaultShellBin, initial: defaultShellInitial),
             shortcut: [:],
             width: defaultWidth)
@@ -117,6 +131,7 @@ struct ConfigLLM: Codable {
     let apiKey: String
     let model: String
     let systemPrompt: String
+    let provider: String? // "openai" or "openrouter"
 }
 
 struct ConfigShell: Codable {


### PR DESCRIPTION
`.clipshortrc.json` 内の `provider` パラメーターで `"openrouter"` を指定することで、OpenAI と同じ仕様の API でさまざまなモデルを利用できる [OpenRouter](https://openrouter.ai) を利用できるようにしました。これにより、Claude や Gemini などのモデルにアクセスできます。

## 変更内容
- `ConfigLLM` 構造体に `provider` フィールドを追加
- OpenAI/OpenRouterのエンドポイント選択ロジックを実装
- プロバイダーに応じたモデル名フォーマット処理
- OpenRouter用の追加ヘッダーサポート
- エラーハンドリングの実装
- デフォルト設定ファイル生成時のプロバイダー設定対応

## 使用方法
設定ファイル ( `~/.clipshortrc.json` ) に以下のように `provider` パラメーターを追加します:

```json
"llm": {
  "provider": "openrouter", // "openai"（デフォルト） または "openrouter"
  "model": "openai/gpt-4o", // OpenRouterの場合はプロバイダー/モデル名形式
  "systemPrompt": "以下の質問に簡潔に回答してください",
  "apiKey": "YOUR_API_KEY" // 対応するプロバイダーのAPIキー
}
```

## その他
OpenRouter に送信される追加ヘッダー（HTTP-Referer, X-Title）は現在ハードコードされています。これらのヘッダーをカスタマイズしたい場合は `Request.swift` 内の以下の部分を変更してください:

```swift
request.addValue("dev.yokohama.clipshort", forHTTPHeaderField: "HTTP-Referer")
request.addValue("Clipshort", forHTTPHeaderField: "X-Title")
```

これらのヘッダーは OpenRouter のランキングページでアプリを識別するために使用されます。